### PR TITLE
Removed duplicated initialization

### DIFF
--- a/Scripts/Runtime/IMU/IMU.cs
+++ b/Scripts/Runtime/IMU/IMU.cs
@@ -68,7 +68,7 @@ namespace FRJ.Sensor
 
             // Raw
             this._geometryQuaternion = new Vector4(this._trans.rotation.x, this._trans.rotation.y, this._trans.rotation.z, this._trans.rotation.w);
-            this._angularVelocity = -1 * this.transform.InverseTransformVector(this.GetComponent<Rigidbody>().angularVelocity);
+            this._angularVelocity = -1 * this.transform.InverseTransformVector(this._rb.angularVelocity);
             this._linearAcceleration = acceleration;
 
             // Apply Gaussian Noise


### PR DESCRIPTION
The rigid body instance is initialized here therefore no more initialization is necessary.
https://github.com/arav-jp/UnitySensors/compare/main...robograffitti:UnitySensors:Scripts/Runtime/IMU/IMU.cs/remove-duplicated-initialization?expand=1#diff-a0ad567cfbeb9309f9b71c7e89c0e50bba8697e1795035fe5aea9ddc97130e22R51